### PR TITLE
Keep white text color for li items with drop-down menus

### DIFF
--- a/new-theme/sjoseph.ucdavis.edu/++theme++quintagroup.theme.sliced/css/sliced.css
+++ b/new-theme/sjoseph.ucdavis.edu/++theme++quintagroup.theme.sliced/css/sliced.css
@@ -73,7 +73,7 @@ td > img {
 a:link {
   color: #127a89;
 }
-a:visited,
+/* a:visited, */
 h1,
 h2,
 h3,
@@ -387,14 +387,22 @@ div.position-0 {
   left: 50%;
   transform: translateX(-50%);
 }
-#theme-globalnav li:hover > a,
+
 #theme-globalnav li.selected > a {
   color: #127a89;
 }
-#theme-globalnav li:hover,
 #theme-globalnav li.selected {
   background-color: #d1cec4;
 }
+
+#theme-globalnav li:hover {
+  background-color: #127a89;
+}
+
+#theme-globalnav li:hover > a {
+  color: white;
+}
+
 #theme-globalnav {
   padding-top: 20px;
   padding-bottom: 20px;
@@ -429,8 +437,17 @@ div.position-0 {
   color: #127a89;
   font: 16px/20px 'Arimo', sans-serif;
 }
-#theme-globalnav li:hover > ul {
+#theme-globalnav:not(.megamenu-nav) li ul:focus a {
+  padding: 15px 30px;
   display: block;
+  color: white;
+  font: 16px/20px 'Arimo', sans-serif;
+}
+#theme-globalnav li:hover > ul {
+  display: inline-block;
+}
+#theme-globalnav li:hover > a {
+  color: white !important;
 }
 #theme-globalnav:not(.megamenu-nav) > li > ul {
   margin-left: -129px;
@@ -1087,9 +1104,9 @@ dl.portlet dt a:hover {
   background: rgba(255, 255, 255, 0.8);
   border: 0;
 }
-.state-published {
+/* .state-published {
   color: #127a89 !important;
-}
+} */
 #content-core dt .contenttype-event {
   font: 20px/28px Georgia;
   padding-bottom: 8px;
@@ -3337,4 +3354,10 @@ dl.portlet ul.social-icons a:hover,
     width: 100%;
     text-align: center;
   }
+}
+
+/*Custom css*/
+.center-contents img{
+  display: block;
+  margin: 0 auto;
 }


### PR DESCRIPTION
Before, when you weren't hovering over the list item whose submenu you were currently interacting with, the text would revert color due to interference with some other stylesheets. Now it doesn't (tested in chrome and firefox).

Before:

![before](https://cloud.githubusercontent.com/assets/7495152/19097407/71076218-8a59-11e6-8027-915e3ec13fd8.png)

After:

![after](https://cloud.githubusercontent.com/assets/7495152/19097408/710851fa-8a59-11e6-9268-2d32c4e4d98c.png)
